### PR TITLE
Improve terminal board rendering

### DIFF
--- a/assets/demo.tape
+++ b/assets/demo.tape
@@ -1,20 +1,21 @@
 Output assets/demo.gif
 
-Require target/debug/twozero48
+# Capture the release binary because debug-mode terminal rendering can be slow
+# enough to show visible tearing in the recording.
+Require target/release/twozero48
 
 Set Shell "zsh"
 Set Theme "OneDark"
 Set Width 1000
-Set Height 800
-Set FontSize 22
+Set Height 930
 Set LetterSpacing 0
-Set LineHeight 1.2
 Set Padding 4
-Set Framerate 24
+# 50 FPS keeps the slide animation smooth while staying reasonable for a GIF.
+Set Framerate 50
 Set TypingSpeed 1ms
 
 Hide
-Type "env -u NO_COLOR COLORTERM=truecolor TERM=xterm-256color ./target/debug/twozero48"
+Type "env -u NO_COLOR COLORTERM=truecolor TERM=xterm-256color ./target/release/twozero48"
 Enter
 Sleep 2s
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -14,7 +14,13 @@ pub(crate) mod render;
 mod terminal;
 
 const FLASH_DURATION: Duration = Duration::from_millis(120);
+const SLIDE_DURATION: Duration = Duration::from_millis(140);
+const SPAWN_DURATION: Duration = Duration::from_millis(90);
 
+/// UI-facing game state plus transient render effects.
+///
+/// This wraps the pure game model with input handling and animation state so
+/// frontends can tick, render, and reset from one stable object.
 pub struct State<R: Rng = ThreadRng> {
     game: Game<R>,
     move_effects: MoveEffects,
@@ -54,7 +60,10 @@ impl<R: Rng> State<R> {
         if self.valid_move {
             self.move_effects
                 .record_move(mov, &old_board, self.game.board());
+            let board_before_spawn = self.game.board().clone();
             self.game.spawn();
+            self.move_effects
+                .record_spawn(&board_before_spawn, self.game.board());
         }
 
         self.game.status()
@@ -95,50 +104,63 @@ impl<R: Rng> State<R> {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct AnimatedTile {
+    /// The visible tile value before any merge promotion at the destination.
+    pub(crate) tile: Tile,
+    /// Source cell in the board before applying the move.
+    pub(crate) from: (usize, usize),
+    /// Destination cell after applying compression and merges.
+    pub(crate) to: (usize, usize),
+}
+
 struct AnimState {
-    dx: i16,
-    dy: i16,
+    tiles: Vec<AnimatedTile>,
     started: Instant,
 }
 
 impl AnimState {
-    fn new(mov: Move) -> Self {
-        let (dx, dy) = match mov {
-            Move::Left => (-2, 0),
-            Move::Right => (2, 0),
-            Move::Up => (0, -2),
-            Move::Down => (0, 2),
-        };
-
+    fn new(mov: Move, old_board: &Board) -> Self {
         Self {
-            dx,
-            dy,
+            tiles: animated_tiles(mov, old_board),
             started: Instant::now(),
         }
     }
 
-    fn shift(&self) -> (i16, i16) {
-        let elapsed = self.started.elapsed().as_millis().min(i16::MAX as u128) as i16;
-        let step = (elapsed / 65).min(3);
-        let remaining = (3 - step).max(0);
-        (self.dx * remaining * 2 / 3, self.dy * remaining * 2 / 3)
+    fn progress(&self) -> f32 {
+        (self.started.elapsed().as_secs_f32() / SLIDE_DURATION.as_secs_f32()).clamp(0.0, 1.0)
+    }
+
+    fn spawn_progress(&self) -> f32 {
+        let elapsed = self.started.elapsed().saturating_sub(SLIDE_DURATION);
+        (elapsed.as_secs_f32() / SPAWN_DURATION.as_secs_f32()).clamp(0.0, 1.0)
     }
 
     fn expired(&self) -> bool {
-        self.started.elapsed() >= Duration::from_millis(200)
+        self.started.elapsed() >= SLIDE_DURATION + SPAWN_DURATION
     }
 }
 
+/// Transient visual effects derived from the most recent move.
+///
+/// Effects are intentionally separate from [`Game`] so animation never changes
+/// the game rules or board state.
 #[derive(Default)]
 pub struct MoveEffects {
     anim: Option<AnimState>,
     flash: HashSet<(usize, usize)>,
     flash_until: Option<Instant>,
+    spawn: Option<(usize, usize)>,
 }
 
 impl MoveEffects {
+    /// Records the slide and merge effects caused by applying a directional move.
+    ///
+    /// The slide animation is derived from the old board because the new board no
+    /// longer contains enough information to distinguish a tile that slid into a
+    /// cell from a tile that was already there.
     pub(crate) fn record_move(&mut self, mov: Move, old_board: &Board, new_board: &Board) {
-        self.anim = Some(AnimState::new(mov));
+        self.anim = Some(AnimState::new(mov, old_board));
         self.flash = changed_cells(old_board, new_board);
         self.flash_until = Some(Instant::now() + FLASH_DURATION);
     }
@@ -152,11 +174,37 @@ impl MoveEffects {
 
         if self.anim.as_ref().is_some_and(AnimState::expired) {
             self.anim = None;
+            self.spawn = None;
         }
     }
 
-    pub(crate) fn shift(&self) -> (i16, i16) {
-        self.anim.as_ref().map_or((0, 0), AnimState::shift)
+    pub(crate) fn record_spawn(&mut self, old_board: &Board, new_board: &Board) {
+        self.spawn = spawned_cells(old_board, new_board);
+    }
+
+    pub(crate) fn animated_tiles(&self) -> &[AnimatedTile] {
+        self.anim.as_ref().map_or(&[], |anim| anim.tiles.as_slice())
+    }
+
+    pub(crate) fn animation_progress(&self) -> f32 {
+        self.anim.as_ref().map_or(1.0, AnimState::progress)
+    }
+
+    pub(crate) fn spawn_progress(&self) -> f32 {
+        self.anim.as_ref().map_or(1.0, AnimState::spawn_progress)
+    }
+
+    pub(crate) fn is_sliding(&self) -> bool {
+        self.animation_progress() < 1.0
+    }
+
+    pub(crate) fn spawning_cell(&self) -> Option<(usize, usize)> {
+        self.spawn
+    }
+
+    pub(crate) fn hides_cell(&self, cell: (usize, usize)) -> bool {
+        (self.is_sliding() && self.animated_tiles().iter().any(|tile| tile.to == cell))
+            || (self.spawn_progress() < 1.0 && self.spawn == Some(cell))
     }
 
     pub(crate) fn flash(&self) -> &HashSet<(usize, usize)> {
@@ -171,6 +219,7 @@ impl MoveEffects {
         self.anim = None;
         self.flash.clear();
         self.flash_until = None;
+        self.spawn = None;
     }
 }
 
@@ -183,4 +232,131 @@ fn changed_cells(old: &Board, new: &Board) -> HashSet<(usize, usize)> {
             t != old[(r, c)] && t != Tile::EMPTY
         })
         .collect()
+}
+
+fn spawned_cells(old: &Board, new: &Board) -> Option<(usize, usize)> {
+    let size = old.size().min(new.size());
+    (0..size)
+        .flat_map(|r| (0..size).map(move |c| (r, c)))
+        .find(|&(r, c)| old[(r, c)] == Tile::EMPTY && new[(r, c)] != Tile::EMPTY)
+}
+
+fn animated_tiles(mov: Move, old: &Board) -> Vec<AnimatedTile> {
+    let size = old.size();
+    (0..size)
+        .flat_map(|lane| animated_lane_tiles(mov, old, lane))
+        .collect()
+}
+
+/// Replays one lane of 2048 compression to recover per-tile slide paths.
+///
+/// `Board::compress_lane` intentionally mutates in place and returns only score,
+/// so animation keeps this read-only mirror that records where each old tile
+/// travels. Both tiles in a merge animate to the same destination; the promoted
+/// tile is then shown by the settled board after the slide phase completes.
+fn animated_lane_tiles(mov: Move, board: &Board, lane: usize) -> Vec<AnimatedTile> {
+    let positions = lane_positions(mov, board.size(), lane);
+    let tiles: Vec<_> = positions
+        .iter()
+        .copied()
+        .filter_map(|pos| {
+            let tile = board[pos];
+            (tile != Tile::EMPTY).then_some((pos, tile))
+        })
+        .collect();
+
+    let mut animated = Vec::new();
+    let mut write = 0;
+    let mut read = 0;
+    while read < tiles.len() {
+        let (from, tile) = tiles[read];
+        let to = positions[write];
+
+        if tiles.get(read + 1).is_some_and(|(_, next)| *next == tile) {
+            animated.push(AnimatedTile { tile, from, to });
+            animated.push(AnimatedTile {
+                tile,
+                from: tiles[read + 1].0,
+                to,
+            });
+            read += 2;
+        } else {
+            if from != to {
+                animated.push(AnimatedTile { tile, from, to });
+            }
+            read += 1;
+        }
+
+        write += 1;
+    }
+
+    animated
+}
+
+fn lane_positions(mov: Move, size: usize, lane: usize) -> Vec<(usize, usize)> {
+    match mov {
+        Move::Left => (0..size).map(|col| (lane, col)).collect(),
+        Move::Right => (0..size).rev().map(|col| (lane, col)).collect(),
+        Move::Up => (0..size).map(|row| (row, lane)).collect(),
+        Move::Down => (0..size).rev().map(|row| (row, lane)).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn animated_tiles_include_only_tiles_that_move_or_merge() {
+        let board = Board::from_grid([
+            [Tile::TWO, Tile::EMPTY, Tile::FOUR, Tile::EMPTY],
+            [Tile::TWO, Tile::TWO, Tile::EMPTY, Tile::EMPTY],
+            [Tile::EMPTY, Tile::EMPTY, Tile::EMPTY, Tile::EMPTY],
+            [Tile::FOUR, Tile::EMPTY, Tile::FOUR, Tile::EMPTY],
+        ])
+        .expect("board ready");
+
+        let animated = animated_tiles(Move::Left, &board);
+
+        assert_eq!(
+            animated,
+            vec![
+                AnimatedTile {
+                    tile: Tile::FOUR,
+                    from: (0, 2),
+                    to: (0, 1),
+                },
+                AnimatedTile {
+                    tile: Tile::TWO,
+                    from: (1, 0),
+                    to: (1, 0),
+                },
+                AnimatedTile {
+                    tile: Tile::TWO,
+                    from: (1, 1),
+                    to: (1, 0),
+                },
+                AnimatedTile {
+                    tile: Tile::FOUR,
+                    from: (3, 0),
+                    to: (3, 0),
+                },
+                AnimatedTile {
+                    tile: Tile::FOUR,
+                    from: (3, 2),
+                    to: (3, 0),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn spawned_cells_tracks_new_tile_after_slide_source_board() {
+        let old = Board::from_grid([[Tile::TWO, Tile::EMPTY], [Tile::EMPTY, Tile::EMPTY]])
+            .expect("board ready");
+        let new = Board::from_grid([[Tile::TWO, Tile::EMPTY], [Tile::EMPTY, Tile::FOUR]])
+            .expect("board ready");
+
+        assert_eq!(spawned_cells(&old, &new), Some((1, 1)));
+    }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -11,18 +11,24 @@ use crate::{Board, Game, Status, Tile};
 
 use super::MoveEffects;
 
-const CELL_W: u16 = 10;
-const CELL_H: u16 = 5;
+const TILE_W: u16 = 14;
+const TILE_H: u16 = 7;
+const GUTTER_W: u16 = 2;
+const GUTTER_H: u16 = 1;
 const HEADER_H: u16 = 2;
 const FOOTER_H: u16 = 2;
-const EMPTY_BG: Color = Color::Rgb(40, 40, 40);
-const MUTED_FG: Color = Color::Rgb(100, 100, 100);
-const TEXT_FG: Color = Color::Rgb(200, 200, 200);
-const TITLE_TWO_FG: Color = Color::Rgb(255, 100, 20);
-const TITLE_ZERO_FG: Color = Color::Rgb(255, 150, 20);
-const TITLE_FOUR_FG: Color = Color::Rgb(200, 20, 120);
-const TITLE_EIGHT_FG: Color = Color::Rgb(80, 20, 220);
-const SCORE_VALUE_FG: Color = Color::Rgb(230, 230, 230);
+const OUTER_GUTTER_H: u16 = 1;
+const BOARD_BG: Color = Color::Rgb(187, 173, 160);
+const EMPTY_BG: Color = Color::Rgb(205, 193, 180);
+const TILE_DARK_FG: Color = Color::Rgb(119, 110, 101);
+const TILE_LIGHT_FG: Color = Color::Rgb(249, 246, 242);
+const MUTED_FG: Color = Color::Rgb(142, 122, 102);
+const TEXT_FG: Color = Color::Rgb(99, 89, 78);
+const TITLE_TWO_FG: Color = Color::Rgb(238, 228, 218);
+const TITLE_ZERO_FG: Color = Color::Rgb(237, 224, 200);
+const TITLE_FOUR_FG: Color = Color::Rgb(242, 177, 121);
+const TITLE_EIGHT_FG: Color = Color::Rgb(246, 124, 95);
+const SCORE_VALUE_FG: Color = Color::Rgb(249, 246, 242);
 const INVALID_MOVE_FG: Color = Color::Rgb(255, 170, 80);
 const WIN_ACCENT: Color = Color::Rgb(255, 215, 90);
 const WIN_BG: Color = Color::Rgb(36, 30, 10);
@@ -30,6 +36,26 @@ const LOSS_ACCENT: Color = Color::Rgb(255, 105, 130);
 const LOSS_BG: Color = Color::Rgb(34, 16, 20);
 const OVERLAY_TEXT_FG: Color = Color::Rgb(225, 225, 225);
 const FLASH_BRIGHTEN: u8 = 70;
+const TILE_BACKGROUNDS: [Color; 12] = [
+    Color::Rgb(238, 228, 218),
+    Color::Rgb(237, 224, 200),
+    Color::Rgb(242, 177, 121),
+    Color::Rgb(245, 149, 99),
+    Color::Rgb(246, 124, 95),
+    Color::Rgb(246, 94, 59),
+    Color::Rgb(237, 207, 114),
+    Color::Rgb(237, 204, 97),
+    Color::Rgb(237, 200, 80),
+    Color::Rgb(237, 197, 63),
+    Color::Rgb(237, 194, 46),
+    Color::Rgb(60, 58, 50),
+];
+
+#[derive(Clone, Copy)]
+struct TilePalette {
+    fg: Color,
+    bg: Color,
+}
 
 fn brighten(color: Color, amt: u8) -> Color {
     match color {
@@ -44,22 +70,23 @@ fn brighten(color: Color, amt: u8) -> Color {
 
 /// Color used to render a tile.
 fn tile_color(tile: Tile) -> Color {
-    match tile.exponent() {
-        0 => Color::Rgb(180, 180, 180),
-        1 => Color::Rgb(255, 220, 80),
-        2 => Color::Rgb(255, 165, 30),
-        3 => Color::Rgb(255, 100, 20),
-        4 => Color::Rgb(240, 50, 50),
-        5 => Color::Rgb(200, 20, 120),
-        6 => Color::Rgb(150, 0, 200),
-        7 => Color::Rgb(80, 20, 220),
-        8 => Color::Rgb(20, 100, 255),
-        9 => Color::Rgb(0, 200, 220),
-        10 => Color::Rgb(20, 220, 120),
-        11 => Color::Rgb(255, 215, 0),
-        12 => Color::Rgb(255, 255, 255),
-        _ => Color::Rgb(200, 200, 200),
-    }
+    tile_palette(tile).bg
+}
+
+fn tile_palette(tile: Tile) -> TilePalette {
+    let exponent = tile.exponent();
+    let bg = match exponent {
+        0 => EMPTY_BG,
+        1..=12 => TILE_BACKGROUNDS[(exponent - 1) as usize],
+        _ => Color::Rgb(45, 45, 40),
+    };
+    let fg = if exponent >= 3 {
+        TILE_LIGHT_FG
+    } else {
+        TILE_DARK_FG
+    };
+
+    TilePalette { fg, bg }
 }
 
 fn fg(color: Color) -> Style {
@@ -78,6 +105,7 @@ fn bold_fg(color: Color) -> Style {
     fg(color).add_modifier(Modifier::BOLD)
 }
 
+/// Complete render input for one terminal frame.
 pub struct Screen<'a, R: Rng> {
     game: &'a Game<R>,
     effects: &'a MoveEffects,
@@ -85,6 +113,7 @@ pub struct Screen<'a, R: Rng> {
 }
 
 impl<'a, R: Rng> Screen<'a, R> {
+    /// Creates a screen from stable game state plus transient move effects.
     pub fn new(game: &'a Game<R>, effects: &'a MoveEffects, valid_move: bool) -> Self {
         Self {
             game,
@@ -93,12 +122,13 @@ impl<'a, R: Rng> Screen<'a, R> {
         }
     }
 
+    /// Renders the frame into the provided Ratatui frame.
     pub fn render(&self, frame: &mut Frame<'_>) {
         let board = self.game.board();
         let layout = BoardLayout::new(frame.area(), board.size());
 
         Header::new(self.game.score(), self.game.largest_tile()).render(frame, layout.header);
-        BoardGrid::new(board, self.effects, layout.cell_w, layout.cell_h).render(
+        BoardGrid::new(board, self.effects, layout.grid_spec).render(
             frame,
             layout.terminal,
             layout.grid,
@@ -116,18 +146,47 @@ struct BoardLayout {
     playfield: Rect,
     footer: Rect,
     grid: Rect,
-    cell_w: u16,
-    cell_h: u16,
+    grid_spec: GridSpec,
+}
+
+/// Board geometry in terminal cells.
+///
+/// A terminal cell is roughly twice as tall as it is wide, so the horizontal
+/// dimensions are doubled relative to the vertical ones. Inner vertical gutters
+/// are drawn as shared one-row separators over the board background, so the
+/// preferred 14x7 tile with a 2-column gutter approximates the original 2048
+/// board's 7:1 tile-to-gap ratio while still scaling down for short terminals.
+#[derive(Clone, Copy)]
+struct GridSpec {
+    tile_w: u16,
+    tile_h: u16,
+    gutter_w: u16,
+    gutter_h: u16,
 }
 
 impl BoardLayout {
     fn new(terminal: Rect, board_size: usize) -> Self {
         let board_size = board_size as u16;
-        // Scale cell width down on narrow terminals
-        let cell_w = (terminal.width / board_size).clamp(4, CELL_W);
-        let cell_h = ((cell_w * CELL_H + CELL_W / 2) / CELL_W).clamp(4, CELL_H);
-        let grid_width = cell_w * board_size;
-        let grid_height = cell_h * board_size;
+        let gutter_w = GUTTER_W;
+        let gutter_h = GUTTER_H;
+        let gutters_w = gutter_w * (board_size + 1);
+        let gutters_h = gutter_h * board_size.saturating_sub(1) + OUTER_GUTTER_H * 2;
+        let available_w = terminal.width.saturating_sub(gutters_w) / board_size;
+        let available_h = terminal
+            .height
+            .saturating_sub(HEADER_H + FOOTER_H)
+            .saturating_sub(gutters_h)
+            / board_size;
+        let tile_h = odd_tile_height(available_h.min(TILE_H));
+        let tile_w = available_w.min(tile_h * 2).clamp(4, TILE_W);
+        let grid_spec = GridSpec {
+            tile_w,
+            tile_h,
+            gutter_w,
+            gutter_h,
+        };
+        let grid_width = tile_w * board_size + gutters_w;
+        let grid_height = tile_h * board_size + gutters_h;
 
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -152,10 +211,16 @@ impl BoardLayout {
             playfield,
             footer: chunks[2],
             grid,
-            cell_w,
-            cell_h,
+            grid_spec,
         }
     }
+}
+
+fn odd_tile_height(height: u16) -> u16 {
+    let height = height.max(1);
+    // Odd tile bodies give the numeric label a real center row. Even-sized
+    // growth is absorbed by the separator rows around the bodies.
+    if height % 2 == 0 { height - 1 } else { height }
 }
 
 struct Header {
@@ -208,29 +273,33 @@ impl Header {
 struct BoardGrid<'a> {
     board: &'a Board,
     effects: &'a MoveEffects,
-    cell_w: u16,
-    cell_h: u16,
+    grid_spec: GridSpec,
 }
 
 impl<'a> BoardGrid<'a> {
-    fn new(board: &'a Board, effects: &'a MoveEffects, cell_w: u16, cell_h: u16) -> Self {
+    fn new(board: &'a Board, effects: &'a MoveEffects, grid_spec: GridSpec) -> Self {
         Self {
             board,
             effects,
-            cell_w,
-            cell_h,
+            grid_spec,
         }
     }
 
     fn render(&self, frame: &mut Frame<'_>, terminal_area: Rect, grid_rect: Rect) {
+        frame.render_widget(Block::default().style(bg_style(BOARD_BG)), grid_rect);
+
         let board_size = self.board.size();
         for row in 0..board_size {
             for col in 0..board_size {
-                let Some(area) = self.shifted_cell_rect(terminal_area, grid_rect, row, col) else {
+                let Some(area) = self.tile_rect(terminal_area, grid_rect, row, col) else {
                     continue;
                 };
 
-                let tile = self.board[(row, col)];
+                let tile = if self.effects.hides_cell((row, col)) {
+                    Tile::EMPTY
+                } else {
+                    self.board[(row, col)]
+                };
                 TileCell::new(
                     tile,
                     tile != Tile::EMPTY && self.effects.flash().contains(&(row, col)),
@@ -238,26 +307,105 @@ impl<'a> BoardGrid<'a> {
                 .render(frame, area);
             }
         }
+        self.render_row_separators(frame, grid_rect);
+
+        if self.effects.is_sliding() {
+            for tile in self.effects.animated_tiles() {
+                let Some(area) = self.animated_tile_rect(terminal_area, grid_rect, tile) else {
+                    continue;
+                };
+
+                TileCell::new(tile.tile, false).render(frame, area);
+            }
+        }
+
+        if let Some((row, col)) = self.effects.spawning_cell() {
+            if let Some(area) = self
+                .tile_rect(terminal_area, grid_rect, row, col)
+                .and_then(|area| scaled_rect(area, self.effects.spawn_progress()))
+            {
+                TileCell::new(self.board[(row, col)], false).render(frame, area);
+            }
+        }
     }
 
-    fn shifted_cell_rect(
+    fn render_row_separators(&self, frame: &mut Frame<'_>, grid_rect: Rect) {
+        let rows = self.board.size().saturating_sub(1) as u16;
+
+        for row in 0..rows {
+            let y = grid_rect.y
+                + OUTER_GUTTER_H
+                + self.grid_spec.tile_h
+                + row * (self.grid_spec.tile_h + self.grid_spec.gutter_h);
+            frame.render_widget(
+                Block::default().style(bg_style(BOARD_BG)),
+                Rect::new(grid_rect.x, y, grid_rect.width, 1),
+            );
+        }
+    }
+
+    fn tile_rect(
         &self,
         terminal_area: Rect,
         grid_rect: Rect,
         row: usize,
         col: usize,
     ) -> Option<Rect> {
-        let (x_shift, y_shift) = self.effects.shift();
-        let x = grid_rect
-            .x
-            .checked_add_signed(col as i16 * self.cell_w as i16 + x_shift)?;
-        let y = grid_rect
-            .y
-            .checked_add_signed(row as i16 * self.cell_h as i16 + y_shift)?;
-        let area = Rect::new(x, y, self.cell_w, self.cell_h);
+        let x = grid_rect.x.checked_add_signed(
+            self.grid_spec.gutter_w as i16
+                + col as i16 * (self.grid_spec.tile_w + self.grid_spec.gutter_w) as i16,
+        )?;
+        let y = grid_rect.y.checked_add_signed(
+            OUTER_GUTTER_H as i16
+                + row as i16 * (self.grid_spec.tile_h + self.grid_spec.gutter_h) as i16,
+        )?;
+        let area = Rect::new(x, y, self.grid_spec.tile_w, self.grid_spec.tile_h);
 
         (area.intersection(terminal_area) == area).then_some(area)
     }
+
+    fn animated_tile_rect(
+        &self,
+        terminal_area: Rect,
+        grid_rect: Rect,
+        tile: &super::AnimatedTile,
+    ) -> Option<Rect> {
+        let from = self.tile_rect(terminal_area, grid_rect, tile.from.0, tile.from.1)?;
+        let to = self.tile_rect(terminal_area, grid_rect, tile.to.0, tile.to.1)?;
+        let progress = self.effects.animation_progress();
+        let x = interpolate(from.x, to.x, progress);
+        let y = interpolate(from.y, to.y, progress);
+        let area = Rect::new(x, y, self.grid_spec.tile_w, self.grid_spec.tile_h);
+
+        (area.intersection(terminal_area) == area).then_some(area)
+    }
+}
+
+fn interpolate(from: u16, to: u16, progress: f32) -> u16 {
+    let from = f32::from(from);
+    let to = f32::from(to);
+
+    (from + (to - from) * progress)
+        .round()
+        .clamp(0.0, f32::from(u16::MAX)) as u16
+}
+
+/// Scales a spawned tile out from the center of its final cell.
+fn scaled_rect(area: Rect, progress: f32) -> Option<Rect> {
+    if progress <= 0.0 {
+        return None;
+    }
+
+    let width = scaled_dimension(area.width, progress);
+    let height = scaled_dimension(area.height, progress);
+    let x = area.x + area.width.saturating_sub(width) / 2;
+    let y = area.y + area.height.saturating_sub(height) / 2;
+
+    Some(Rect::new(x, y, width, height))
+}
+
+fn scaled_dimension(size: u16, progress: f32) -> u16 {
+    ((f32::from(size) * progress).ceil() as u16).clamp(1, size)
 }
 
 struct TileCell {
@@ -271,39 +419,33 @@ impl TileCell {
     }
 
     fn render(&self, frame: &mut Frame<'_>, area: Rect) {
-        let bg = self.background();
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .style(bg_style(bg));
-        let inner = block.inner(area);
+        let palette = self.palette();
 
-        frame.render_widget(block, area);
+        frame.render_widget(Block::default().style(bg_style(palette.bg)), area);
         if self.tile == Tile::EMPTY {
             return;
         }
 
+        let text = self.tile.to_string();
+        let text_width = text.chars().count() as u16;
+        let text_x = area.x + area.width.saturating_sub(text_width) / 2;
+        let text_y = area.y + area.height / 2;
+
         frame.render_widget(
             Paragraph::new(Span::styled(
-                self.tile.to_string(),
-                fg_bg(Color::White, bg).add_modifier(Modifier::BOLD),
-            ))
-            .alignment(Alignment::Center),
-            Rect::new(inner.x, inner.y + inner.height / 2, inner.width, 1),
+                text,
+                fg_bg(palette.fg, palette.bg).add_modifier(Modifier::BOLD),
+            )),
+            Rect::new(text_x, text_y, text_width, 1),
         );
     }
 
-    fn background(&self) -> Color {
-        if self.tile == Tile::EMPTY {
-            return EMPTY_BG;
+    fn palette(&self) -> TilePalette {
+        let mut palette = tile_palette(self.tile);
+        if self.flashing && self.tile != Tile::EMPTY {
+            palette.bg = brighten(palette.bg, FLASH_BRIGHTEN);
         }
-
-        let color = tile_color(self.tile);
-        if self.flashing {
-            brighten(color, FLASH_BRIGHTEN)
-        } else {
-            color
-        }
+        palette
     }
 }
 
@@ -364,6 +506,7 @@ fn render_centered_line(frame: &mut Frame<'_>, line: Line<'_>, area: Rect) {
     frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
 }
 
+/// Game-end overlay content.
 #[derive(Clone, Debug)]
 pub struct Overlay {
     title: &'static str,
@@ -383,6 +526,7 @@ impl Overlay {
         Ok(overlay)
     }
 
+    /// Creates the win overlay for a completed game.
     pub fn won(score: usize, winning: Tile) -> Self {
         Self {
             title: "You won! Great job.",
@@ -392,6 +536,7 @@ impl Overlay {
         }
     }
 
+    /// Creates the loss overlay for a completed game.
     pub fn lost(score: usize, largest: Tile) -> Self {
         Self {
             title: "Game over :(",
@@ -524,6 +669,82 @@ mod tests {
     }
 
     #[test]
+    fn tile_numbers_follow_original_foreground_split() {
+        assert_eq!(tile_palette(Tile::TWO).fg, TILE_DARK_FG);
+        assert_eq!(tile_palette(Tile::FOUR).fg, TILE_DARK_FG);
+        assert_eq!(tile_palette(Tile::new(3)).fg, TILE_LIGHT_FG);
+        assert_eq!(tile_palette(Tile::new(11)).fg, TILE_LIGHT_FG);
+        assert_eq!(tile_palette(Tile::new(12)).fg, TILE_LIGHT_FG);
+    }
+
+    #[test]
+    fn tile_numbers_center_left_when_width_is_uneven() {
+        let mut tui = test_tui(10, 5);
+
+        tui.0
+            .draw(|frame| TileCell::new(Tile::new(7), false).render(frame, frame.area()))
+            .expect("failed to draw tile");
+
+        let buffer = tui.0.backend().buffer();
+        assert_eq!(buffer[(3, 2)].symbol(), "1");
+        assert_eq!(buffer[(4, 2)].symbol(), "2");
+        assert_eq!(buffer[(5, 2)].symbol(), "8");
+        assert_eq!(buffer[(6, 2)].symbol(), " ");
+    }
+
+    #[test]
+    fn grid_gutters_match_outer_margins() {
+        let board = Board::new(4).expect("board created");
+        let effects = MoveEffects::default();
+        let grid = BoardGrid::new(
+            &board,
+            &effects,
+            GridSpec {
+                tile_w: TILE_W,
+                tile_h: TILE_H,
+                gutter_w: GUTTER_W,
+                gutter_h: GUTTER_H,
+            },
+        );
+        let terminal = Rect::new(0, 0, 80, 40);
+        let grid_rect = Rect::new(10, 20, 66, 30);
+
+        assert_eq!(
+            grid.tile_rect(terminal, grid_rect, 0, 0),
+            Some(Rect::new(12, 21, 14, 7))
+        );
+        assert_eq!(
+            grid.tile_rect(terminal, grid_rect, 0, 1),
+            Some(Rect::new(28, 21, 14, 7))
+        );
+        assert_eq!(
+            grid.tile_rect(terminal, grid_rect, 0, 3),
+            Some(Rect::new(60, 21, 14, 7))
+        );
+    }
+
+    #[test]
+    fn layout_prefers_seven_to_one_tile_gutters_when_roomy() {
+        let layout = BoardLayout::new(Rect::new(0, 0, 80, 40), 4);
+
+        assert_eq!(layout.grid_spec.tile_w, 14);
+        assert_eq!(layout.grid_spec.tile_h, 7);
+        assert_eq!(layout.grid_spec.gutter_w, 2);
+        assert_eq!(layout.grid_spec.gutter_h, 1);
+        assert_eq!(layout.grid.height, 33);
+    }
+
+    #[test]
+    fn layout_scales_down_to_fit_short_terminals() {
+        let layout = BoardLayout::new(Rect::new(0, 0, 80, 23), 4);
+
+        assert_eq!(layout.grid_spec.tile_w, 6);
+        assert_eq!(layout.grid_spec.tile_h, 3);
+        assert_eq!(layout.grid.width, 34);
+        assert_eq!(layout.grid.height, 17);
+    }
+
+    #[test]
     fn render_keeps_grid_below_score_header_at_minimum_board_height() {
         let board = Board::new(4).expect("board created");
         let mut tui = test_tui(80, 23);
@@ -535,10 +756,140 @@ mod tests {
 
         let buffer = tui.0.backend().buffer();
         let score_line = buffer_line(buffer, 1);
-        let first_grid_line = buffer_line(buffer, 2);
+        let first_grid_line = buffer_line(buffer, 3);
+        let grid_left = 23;
 
         assert!(score_line.contains("SCORE"), "{score_line}");
         assert!(!score_line.contains("╭"), "{score_line}");
-        assert!(first_grid_line.contains("╭"), "{first_grid_line}");
+        assert!(!first_grid_line.contains("╭"), "{first_grid_line}");
+        assert_eq!(buffer[(grid_left, 3)].bg, BOARD_BG);
+        assert_eq!(buffer[(grid_left + 1, 3)].bg, BOARD_BG);
+        assert_eq!(buffer[(grid_left + 2, 3)].bg, BOARD_BG);
+        assert_eq!(buffer[(grid_left + 2, 4)].bg, EMPTY_BG);
+        assert_eq!(buffer[(grid_left + 2, 5)].bg, EMPTY_BG);
+    }
+
+    #[test]
+    fn visual_grid_rows_stay_stable_at_short_size() {
+        assert_visual_grid(
+            80,
+            23,
+            34,
+            17,
+            6,
+            3,
+            [
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BB......BB......BB......BB......BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            ],
+        );
+    }
+
+    #[test]
+    fn visual_grid_rows_stay_stable_at_roomy_size() {
+        assert_visual_grid(
+            80,
+            40,
+            66,
+            33,
+            14,
+            7,
+            [
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BB..............BB..............BB..............BB..............BB",
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            ],
+        );
+    }
+
+    fn assert_visual_grid<const H: usize>(
+        width: u16,
+        height: u16,
+        grid_w: u16,
+        grid_h: u16,
+        tile_w: u16,
+        tile_h: u16,
+        expected: [&str; H],
+    ) {
+        let board = Board::new(4).expect("board created");
+        let mut tui = test_tui(width, height);
+        let game = Game::from_parts(board, Tile::new(11), 0);
+        let effects = MoveEffects::default();
+
+        let screen = Screen::new(&game, &effects, true);
+        tui.draw(screen).expect("failed to draw screen");
+
+        let buffer = tui.0.backend().buffer();
+        let layout = BoardLayout::new(Rect::new(0, 0, width, height), 4);
+        assert_eq!(layout.grid.width, grid_w);
+        assert_eq!(layout.grid.height, grid_h);
+        assert_eq!(layout.grid_spec.tile_w, tile_w);
+        assert_eq!(layout.grid_spec.tile_h, tile_h);
+        assert_eq!(grid_visual(buffer, layout.grid), expected.join("\n"));
+    }
+
+    fn grid_visual(buffer: &Buffer, grid: Rect) -> String {
+        let mut view = String::new();
+        for y in grid.y..grid.y + grid.height {
+            if y > grid.y {
+                view.push('\n');
+            }
+            for x in grid.x..grid.x + grid.width {
+                let cell = &buffer[(x, y)];
+                if cell.bg == BOARD_BG {
+                    view.push('B');
+                } else if cell.bg == EMPTY_BG {
+                    view.push('.');
+                } else {
+                    view.push(' ');
+                }
+            }
+        }
+        view
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to rendering feedback in https://github.com/ratatui/ratatui-website/issues/1145#issuecomment-4590012649.

- make the board spacing and colors closer to the original 2048
- animate individual tiles instead of shifting the whole board
- spawn new tiles after the slide, expanding from the center
- add visual buffer tests for the board geometry
- update the VHS tape to record the release binary at 50 FPS

## Demo

![demo.gif](https://github.com/joshka/twozero48/blob/6aba4898b18e05a7e75a82994b2e589813606ea5/demo.gif?raw=true)

## Rationale

The previous rounded tile borders made the grid feel less like 2048 and were hard to size cleanly in terminal cells. This moves spacing into board-owned gutters/separators, which keeps tile bodies aligned and makes the horizontal and vertical proportions easier to reason about.

Animating individual tiles also avoids the aggressive whole-board bump. Delaying the spawned tile until after the slide better matches the expected 2048 motion, and the center expansion makes new tiles feel intentional rather than appearing abruptly.

The VHS tape now uses the release binary because debug rendering can be slow enough to show tearing in a recording. It records at 50 FPS because GIF frame delays work best at 50 FPS or clean divisors.

The generated GIF is intentionally not committed. Large binary assets make Git repositories grow permanently, and removing them later requires history rewriting. If this demo should be published, better options are `vhs publish`, GitHub release assets, Git LFS, or similar external asset hosting.

## Verification

- `cargo test`
- `cargo build --release`
- `vhs assets/demo.tape`
